### PR TITLE
Try this again

### DIFF
--- a/src/main/java/li/cil/oc2/client/renderer/NetworkCableRenderer.java
+++ b/src/main/java/li/cil/oc2/client/renderer/NetworkCableRenderer.java
@@ -47,7 +47,7 @@ public final class NetworkCableRenderer {
     private static final int CABLE_SWING_INTERVAL = 8000;
     private static final float CABLE_HANG_MIN = 0.1f;
     private static final float CABLE_HANG_MAX = 0.5f;
-    private static final float CABLE_MAX_LENGTH = 64f;
+    private static final float CABLE_MAX_LENGTH = 32f;
     private static final Vector3f CABLE_COLOR = new Vector3f(0.0f, 0.33f, 0.4f);
 
     private static final Set<NetworkConnectorBlockEntity> connectors = Collections.newSetFromMap(new WeakHashMap<>());

--- a/src/main/java/li/cil/oc2/client/renderer/NetworkCableRenderer.java
+++ b/src/main/java/li/cil/oc2/client/renderer/NetworkCableRenderer.java
@@ -47,7 +47,7 @@ public final class NetworkCableRenderer {
     private static final int CABLE_SWING_INTERVAL = 8000;
     private static final float CABLE_HANG_MIN = 0.1f;
     private static final float CABLE_HANG_MAX = 0.5f;
-    private static final float CABLE_MAX_LENGTH = 32f;
+    private static final float CABLE_MAX_LENGTH = 128f;
     private static final Vector3f CABLE_COLOR = new Vector3f(0.0f, 0.33f, 0.4f);
 
     private static final Set<NetworkConnectorBlockEntity> connectors = Collections.newSetFromMap(new WeakHashMap<>());

--- a/src/main/java/li/cil/oc2/common/blockentity/NetworkConnectorBlockEntity.java
+++ b/src/main/java/li/cil/oc2/common/blockentity/NetworkConnectorBlockEntity.java
@@ -53,7 +53,7 @@ public final class NetworkConnectorBlockEntity extends ModBlockEntity implements
 
     private static final int RETRY_UNLOADED_CHUNK_INTERVAL = TickUtils.toTicks(Duration.ofSeconds(5));
     private static final int MAX_CONNECTION_COUNT = 2;
-    private static final int MAX_CONNECTION_DISTANCE = 16;
+    private static final int MAX_CONNECTION_DISTANCE = 64;
     private static final int BYTES_PER_TICK = 64 * 1024 / TickUtils.toTicks(Duration.ofSeconds(1)); // bytes / sec -> bytes / tick
     private static final int MIN_ETHERNET_FRAME_SIZE = 42;
     private static final int TTL_COST = 1;


### PR DESCRIPTION
<div class="span12 boxshadow">

  | ca83
-- | --
ʄ | LATIN SMALL LETTER DOTLESS J WITH STROKE AND HOOK (U+0284) | ca84
ʅ | LATIN SMALL LETTER SQUAT REVERSED ESH (U+0285) | ca85
ʆ | LATIN SMALL LETTER ESH WITH CURL (U+0286) | ca86
ʇ | LATIN SMALL LETTER TURNED T (U+0287) | ca87
ʈ | LATIN SMALL LETTER T WITH RETROFLEX HOOK (U+0288) | ca88
ʉ | LATIN SMALL LETTER U BAR (U+0289) | ca89
ʊ | LATIN SMALL LETTER UPSILON (U+028A) | ca8a
ʋ | LATIN SMALL LETTER V WITH HOOK (U+028B) | ca8b
ʌ | LATIN SMALL LETTER TURNED V (U+028C) | ca8c
ʍ | LATIN SMALL LETTER TURNED W (U+028D) | ca8d
ʎ | LATIN SMALL LETTER TURNED Y (U+028E) | ca8e
ʏ | LATIN LETTER SMALL CAPITAL Y (U+028F) | ca8f
ʐ | LATIN SMALL LETTER Z WITH RETROFLEX HOOK (U+0290) | ca90
ʑ | LATIN SMALL LETTER Z WITH CURL (U+0291) | ca91
ʒ | LATIN SMALL LETTER EZH (U+0292) | ca92
ʓ | LATIN SMALL LETTER EZH WITH CURL (U+0293) | ca93
ʔ | LATIN LETTER GLOTTAL STOP (U+0294) | ca94
ʕ | LATIN LETTER PHARYNGEAL VOICED FRICATIVE (U+0295) | ca95
ʖ | LATIN LETTER INVERTED GLOTTAL STOP (U+0296) | ca96
ʗ | LATIN LETTER STRETCHED C (U+0297) | ca97
ʘ | LATIN LETTER BILABIAL CLICK (U+0298) | ca98
ʙ | LATIN LETTER SMALL CAPITAL B (U+0299) | ca99
ʚ | LATIN SMALL LETTER CLOSED OPEN E (U+029A) | ca9a
ʛ | LATIN LETTER SMALL CAPITAL G WITH HOOK (U+029B) | ca9b
ʜ | LATIN LETTER SMALL CAPITAL H (U+029C) | ca9c
ʝ | LATIN SMALL LETTER J WITH CROSSED-TAIL (U+029D) | ca9d
ʞ | LATIN SMALL LETTER TURNED K (U+029E) | ca9e
ʟ | LATIN LETTER SMALL CAPITAL L (U+029F) | ca9f
ʠ | LATIN SMALL LETTER Q WITH HOOK (U+02A0) | caa0
ʡ | LATIN LETTER GLOTTAL STOP WITH STROKE (U+02A1) | caa1
ʢ | LATIN LETTER REVERSED GLOTTAL STOP WITH STROKE (U+02A2) | caa2
ʣ | LATIN SMALL LETTER DZ DIGRAPH (U+02A3) | caa3
ʤ | LATIN SMALL LETTER DEZH DIGRAPH (U+02A4) | caa4
ʥ | LATIN SMALL LETTER DZ DIGRAPH WITH CURL (U+02A5) | caa5
ʦ | LATIN SMALL LETTER TS DIGRAPH (U+02A6) | caa6
ʧ | LATIN SMALL LETTER TESH DIGRAPH (U+02A7) | caa7
ʨ | LATIN SMALL LETTER TC DIGRAPH WITH CURL (U+02A8) | caa8
ʩ | LATIN SMALL LETTER FENG DIGRAPH (U+02A9) | caa9
ʪ | LATIN SMALL LETTER LS DIGRAPH (U+02AA) | caaa
ʫ | LATIN SMALL LETTER LZ DIGRAPH (U+02AB) | caab
ʬ | LATIN LETTER BILABIAL PERCUSSIVE (U+02AC) | caac
ʭ | LATIN LETTER BIDENTAL PERCUSSIVE (U+02AD) | caad
ʮ | LATIN SMALL LETTER TURNED H WITH FISHHOOK (U+02AE) | caae
ʯ | LATIN SMALL LETTER TURNED H WITH FISHHOOK AND TAIL (U+02AF) | caaf
ʰ | MODIFIER LETTER SMALL H (U+02B0) | cab0
ʱ | MODIFIER LETTER SMALL H WITH HOOK (U+02B1) | cab1
ʲ | MODIFIER LETTER SMALL J (U+02B2) | cab2
ʳ | MODIFIER LETTER SMALL R (U+02B3) | cab3
ʴ | MODIFIER LETTER SMALL TURNED R (U+02B4) | cab4
ʵ | MODIFIER LETTER SMALL TURNED R WITH HOOK (U+02B5) | cab5
ʶ | MODIFIER LETTER SMALL CAPITAL INVERTED R (U+02B6) | cab6
ʷ | MODIFIER LETTER SMALL W (U+02B7) | cab7
ʸ | MODIFIER LETTER SMALL Y (U+02B8) | cab8
ʹ | MODIFIER LETTER PRIME (U+02B9) | cab9
ʺ | MODIFIER LETTER DOUBLE PRIME (U+02BA) | caba
ʻ | MODIFIER LETTER TURNED COMMA (U+02BB) | cabb
ʼ | MODIFIER LETTER APOSTROPHE (U+02BC) | cabc
ʽ | MODIFIER LETTER REVERSED COMMA (U+02BD) | cabd
ʾ | MODIFIER LETTER RIGHT HALF RING (U+02BE) | cabe
ʿ | MODIFIER LETTER LEFT HALF RING (U+02BF) | cabf
ˀ | MODIFIER LETTER GLOTTAL STOP (U+02C0) | cb80
ˁ | MODIFIER LETTER REVERSED GLOTTAL STOP (U+02C1) | cb81
˂ | MODIFIER LETTER LEFT ARROWHEAD (U+02C2) | cb82
˃ | MODIFIER LETTER RIGHT ARROWHEAD (U+02C3) | cb83
˄ | MODIFIER LETTER UP ARROWHEAD (U+02C4) | cb84
˅ | MODIFIER LETTER DOWN ARROWHEAD (U+02C5) | cb85
ˆ | MODIFIER LETTER CIRCUMFLEX ACCENT (U+02C6) | cb86
ˇ | CARON (U+02C7) | cb87
ˈ | MODIFIER LETTER VERTICAL LINE (U+02C8) | cb88
ˉ | MODIFIER LETTER MACRON (U+02C9) | cb89
ˊ | MODIFIER LETTER ACUTE ACCENT (U+02CA) | cb8a
ˋ | MODIFIER LETTER GRAVE ACCENT (U+02CB) | cb8b
ˌ | MODIFIER LETTER LOW VERTICAL LINE (U+02CC) | cb8c
ˍ | MODIFIER LETTER LOW MACRON (U+02CD) | cb8d
ˎ | MODIFIER LETTER LOW GRAVE ACCENT (U+02CE) | cb8e
ˏ | MODIFIER LETTER LOW ACUTE ACCENT (U+02CF) | cb8f
ː | MODIFIER LETTER TRIANGULAR COLON (U+02D0) | cb90
ˑ | MODIFIER LETTER HALF TRIANGULAR COLON (U+02D1) | cb91
˒ | MODIFIER LETTER CENTRED RIGHT HALF RING (U+02D2) | cb92
˓ | MODIFIER LETTER CENTRED LEFT HALF RING (U+02D3) | cb93
˔ | MODIFIER LETTER UP TACK (U+02D4) | cb94
˕ | MODIFIER LETTER DOWN TACK (U+02D5) | cb95
˖ | MODIFIER LETTER PLUS SIGN (U+02D6) | cb96
˗ | MODIFIER LETTER MINUS SIGN (U+02D7) | cb97
˘ | BREVE (U+02D8) | cb98
˙ | DOT ABOVE (U+02D9) | cb99
˚ | RING ABOVE (U+02DA) | cb9a
˛ | OGONEK (U+02DB) | cb9b
˜ | SMALL TILDE (U+02DC) | cb9c
˝ | DOUBLE ACUTE ACCENT (U+02DD) | cb9d
˞ | MODIFIER LETTER RHOTIC HOOK (U+02DE) | cb9e
˟ | MODIFIER LETTER CROSS ACCENT (U+02DF) | cb9f
ˠ | MODIFIER LETTER SMALL GAMMA (U+02E0) | cba0
ˡ | MODIFIER LETTER SMALL L (U+02E1) | cba1
ˢ | MODIFIER LETTER SMALL S (U+02E2) | cba2
ˣ | MODIFIER LETTER SMALL X (U+02E3) | cba3
ˤ | MODIFIER LETTER SMALL REVERSED GLOTTAL STOP (U+02E4) | cba4
˥ | MODIFIER LETTER EXTRA-HIGH TONE BAR (U+02E5) | cba5
˦ | MODIFIER LETTER HIGH TONE BAR (U+02E6) | cba6
˧ | MODIFIER LETTER MID TONE BAR (U+02E7) | cba7
˨ | MODIFIER LETTER LOW TONE BAR (U+02E8) | cba8
˩ | MODIFIER LETTER EXTRA-LOW TONE BAR (U+02E9) | cba9
˪ | MODIFIER LETTER YIN DEPARTING TONE MARK (U+02EA) | cbaa
˫ | MODIFIER LETTER YANG DEPARTING TONE MARK (U+02EB) | cbab
ˬ | MODIFIER LETTER VOICING (U+02EC) | cbac
˭ | MODIFIER LETTER UNASPIRATED (U+02ED) | cbad
ˮ | MODIFIER LETTER DOUBLE APOSTROPHE (U+02EE) | cbae
˯ | MODIFIER LETTER LOW DOWN ARROWHEAD (U+02EF) | cbaf
˰ | MODIFIER LETTER LOW UP ARROWHEAD (U+02F0) | cbb0
˱ | MODIFIER LETTER LOW LEFT ARROWHEAD (U+02F1) | cbb1
˲ | MODIFIER LETTER LOW RIGHT ARROWHEAD (U+02F2) | cbb2
˳ | MODIFIER LETTER LOW RING (U+02F3) | cbb3
˴ | MODIFIER LETTER MIDDLE GRAVE ACCENT (U+02F4) | cbb4
˵ | MODIFIER LETTER MIDDLE DOUBLE GRAVE ACCENT (U+02F5) | cbb5
˶ | MODIFIER LETTER MIDDLE DOUBLE ACUTE ACCENT (U+02F6) | cbb6
˷ | MODIFIER LETTER LOW TILDE (U+02F7) | cbb7
˸ | MODIFIER LETTER RAISED COLON (U+02F8) | cbb8
˹ | MODIFIER LETTER BEGIN HIGH TONE (U+02F9) | cbb9
˺ | MODIFIER LETTER END HIGH TONE (U+02FA) | cbba
˻ | MODIFIER LETTER BEGIN LOW TONE (U+02FB) | cbbb
˼ | MODIFIER LETTER END LOW TONE (U+02FC) | cbbc
˽ | MODIFIER LETTER SHELF (U+02FD) | cbbd
˾ | MODIFIER LETTER OPEN SHELF (U+02FE) | cbbe
˿ | MODIFIER LETTER LOW LEFT ARROW (U+02FF) | cbbf
̀ | COMBINING GRAVE ACCENT (U+0300) | cc80
́ | COMBINING ACUTE ACCENT (U+0301) | cc81
̂ | COMBINING CIRCUMFLEX ACCENT (U+0302) | cc82
̃ | COMBINING TILDE (U+0303) | cc83
̄ | COMBINING MACRON (U+0304) | cc84
̅ | COMBINING OVERLINE (U+0305) | cc85
̆ | COMBINING BREVE (U+0306) | cc86
̇ | COMBINING DOT ABOVE (U+0307) | cc87
̈ | COMBINING DIAERESIS (U+0308) | cc88
̉ | COMBINING HOOK ABOVE (U+0309) | cc89
̊ | COMBINING RING ABOVE (U+030A) | cc8a
̋ | COMBINING DOUBLE ACUTE ACCENT (U+030B) | cc8b
̌ | COMBINING CARON (U+030C) | cc8c
̍ | COMBINING VERTICAL LINE ABOVE (U+030D) | cc8d
̎ | COMBINING DOUBLE VERTICAL LINE ABOVE (U+030E) | cc8e
̏ | COMBINING DOUBLE GRAVE ACCENT (U+030F) | cc8f
̐ | COMBINING CANDRABINDU (U+0310) | cc90
̑ | COMBINING INVERTED BREVE (U+0311) | cc91
̒ | COMBINING TURNED COMMA ABOVE (U+0312) | cc92
̓ | COMBINING COMMA ABOVE (U+0313) | cc93
̔ | COMBINING REVERSED COMMA ABOVE (U+0314) | cc94
̕ | COMBINING COMMA ABOVE RIGHT (U+0315) | cc95
̖ | COMBINING GRAVE ACCENT BELOW (U+0316) | cc96
̗ | COMBINING ACUTE ACCENT BELOW (U+0317) | cc97
̘ | COMBINING LEFT TACK BELOW (U+0318) | cc98
̙ | COMBINING RIGHT TACK BELOW (U+0319) | cc99
̚ | COMBINING LEFT ANGLE ABOVE (U+031A) | cc9a
̛ | COMBINING HORN (U+031B) | cc9b
̜ | COMBINING LEFT HALF RING BELOW (U+031C) | cc9c
̝ | COMBINING UP TACK BELOW (U+031D) | cc9d
̞ | COMBINING DOWN TACK BELOW (U+031E) | cc9e
̟ | COMBINING PLUS SIGN BELOW (U+031F) | cc9f
̠ | COMBINING MINUS SIGN BELOW (U+0320) | cca0
̡ | COMBINING PALATALIZED HOOK BELOW (U+0321) | cca1
̢ | COMBINING RETROFLEX HOOK BELOW (U+0322) | cca2
̣ | COMBINING DOT BELOW (U+0323) | cca3
̤ | COMBINING DIAERESIS BELOW (U+0324) | cca4
̥ | COMBINING RING BELOW (U+0325) | cca5
̦ | COMBINING COMMA BELOW (U+0326) | cca6
̧ | COMBINING CEDILLA (U+0327) | cca7
̨ | COMBINING OGONEK (U+0328) | cca8
̩ | COMBINING VERTICAL LINE BELOW (U+0329) | cca9
̪ | COMBINING BRIDGE BELOW (U+032A) | ccaa
̫ | COMBINING INVERTED DOUBLE ARCH BELOW (U+032B) | ccab
̬ | COMBINING CARON BELOW (U+032C) | ccac
̭ | COMBINING CIRCUMFLEX ACCENT BELOW (U+032D) | ccad
̮ | COMBINING BREVE BELOW (U+032E) | ccae
̯ | COMBINING INVERTED BREVE BELOW (U+032F) | ccaf
̰ | COMBINING TILDE BELOW (U+0330) | ccb0
̱ | COMBINING MACRON BELOW (U+0331) | ccb1
̲ | COMBINING LOW LINE (U+0332) | ccb2
̳ | COMBINING DOUBLE LOW LINE (U+0333) | ccb3
̴ | COMBINING TILDE OVERLAY (U+0334) | ccb4
̵ | COMBINING SHORT STROKE OVERLAY (U+0335) | ccb5
̶ | COMBINING LONG STROKE OVERLAY (U+0336) | ccb6
̷ | COMBINING SHORT SOLIDUS OVERLAY (U+0337) | ccb7
̸ | COMBINING LONG SOLIDUS OVERLAY (U+0338) | ccb8
̹ | COMBINING RIGHT HALF RING BELOW (U+0339) | ccb9
̺ | COMBINING INVERTED BRIDGE BELOW (U+033A) | ccba
̻ | COMBINING SQUARE BELOW (U+033B) | ccbb
̼ | COMBINING SEAGULL BELOW (U+033C) | ccbc
̽ | COMBINING X ABOVE (U+033D) | ccbd
̾ | COMBINING VERTICAL TILDE (U+033E) | ccbe
̿ | COMBINING DOUBLE OVERLINE (U+033F) | ccbf
̀ | COMBINING GRAVE TONE MARK (U+0340) | cd80
́ | COMBINING ACUTE TONE MARK (U+0341) | cd81
͂ | COMBINING GREEK PERISPOMENI (U+0342) | cd82
̓ | COMBINING GREEK KORONIS (U+0343) | cd83
̈́ | COMBINING GREEK DIALYTIKA TONOS (U+0344) | cd84
ͅ | COMBINING GREEK YPOGEGRAMMENI (U+0345) | cd85
͆ | COMBINING BRIDGE ABOVE (U+0346) | cd86
͇ | COMBINING EQUALS SIGN BELOW (U+0347) | cd87
͈ | COMBINING DOUBLE VERTICAL LINE BELOW (U+0348) | cd88
͉ | COMBINING LEFT ANGLE BELOW (U+0349) | cd89
͊ | COMBINING NOT TILDE ABOVE (U+034A) | cd8a
͋ | COMBINING HOMOTHETIC ABOVE (U+034B) | cd8b
͌ | COMBINING ALMOST EQUAL TO ABOVE (U+034C) | cd8c
͍ | COMBINING LEFT RIGHT ARROW BELOW (U+034D) | cd8d
͎ | COMBINING UPWARDS ARROW BELOW (U+034E) | cd8e
͏ | COMBINING GRAPHEME JOINER (U+034F) | cd8f
͐ | COMBINING RIGHT ARROWHEAD ABOVE (U+0350) | cd90
͑ | COMBINING LEFT HALF RING ABOVE (U+0351) | cd91
͒ | COMBINING FERMATA (U+0352) | cd92
͓ | COMBINING X BELOW (U+0353) | cd93
͔ | COMBINING LEFT ARROWHEAD BELOW (U+0354) | cd94
͕ | COMBINING RIGHT ARROWHEAD BELOW (U+0355) | cd95
͖ | COMBINING RIGHT ARROWHEAD AND UP ARROWHEAD BELOW (U+0356) | cd96
͗ | COMBINING RIGHT HALF RING ABOVE (U+0357) | cd97
͘ | COMBINING DOT ABOVE RIGHT (U+0358) | cd98
͙ | COMBINING ASTERISK BELOW (U+0359) | cd99
͚ | COMBINING DOUBLE RING BELOW (U+035A) | cd9a
͛ | COMBINING ZIGZAG ABOVE (U+035B) | cd9b
͜ | COMBINING DOUBLE BREVE BELOW (U+035C) | cd9c
͝ | COMBINING DOUBLE BREVE (U+035D) | cd9d
͞ | COMBINING DOUBLE MACRON (U+035E) | cd9e
͟ | COMBINING DOUBLE MACRON BELOW (U+035F) | cd9f
͠ | COMBINING DOUBLE TILDE (U+0360) | cda0
͡ | COMBINING DOUBLE INVERTED BREVE (U+0361) | cda1
͢ | COMBINING DOUBLE RIGHTWARDS ARROW BELOW (U+0362) | cda2
ͣ | COMBINING LATIN SMALL LETTER A (U+0363) | cda3
ͤ | COMBINING LATIN SMALL LETTER E (U+0364) | cda4
ͥ | COMBINING LATIN SMALL LETTER I (U+0365) | cda5
ͦ | COMBINING LATIN SMALL LETTER O (U+0366) | cda6
ͧ | COMBINING LATIN SMALL LETTER U (U+0367) | cda7
ͨ | COMBINING LATIN SMALL LETTER C (U+0368) | cda8
ͩ | COMBINING LATIN SMALL LETTER D (U+0369) | cda9
ͪ | COMBINING LATIN SMALL LETTER H (U+036A) | cdaa
ͫ | COMBINING LATIN SMALL LETTER M (U+036B) | cdab
ͬ | COMBINING LATIN SMALL LETTER R (U+036C) | cdac
ͭ | COMBINING LATIN SMALL LETTER T (U+036D) | cdad
ͮ | COMBINING LATIN SMALL LETTER V (U+036E) | cdae
ͯ | COMBINING LATIN SMALL LETTER X (U+036F) | cdaf
Ͱ | GREEK CAPITAL LETTER HETA (U+0370) | cdb0
ͱ | GREEK SMALL LETTER HETA (U+0371) | cdb1
Ͳ | GREEK CAPITAL LETTER ARCHAIC SAMPI (U+0372) | cdb2
ͳ | GREEK SMALL LETTER ARCHAIC SAMPI (U+0373) | cdb3
ʹ | GREEK NUMERAL SIGN (U+0374) | cdb4
͵ | GREEK LOWER NUMERAL SIGN (U+0375) | cdb5
Ͷ | GREEK CAPITAL LETTER PAMPHYLIAN DIGAMMA (U+0376) | cdb6
ͷ | GREEK SMALL LETTER PAMPHYLIAN DIGAMMA (U+0377) | cdb7
ͺ | GREEK YPOGEGRAMMENI (U+037A) | cdba
ͻ | GREEK SMALL REVERSED LUNATE SIGMA SYMBOL (U+037B) | cdbb
ͼ | GREEK SMALL DOTTED LUNATE SIGMA SYMBOL (U+037C) | cdbc
ͽ | GREEK SMALL REVERSED DOTTED LUNATE SIGMA SYMBOL (U+037D) | cdbd
; | GREEK QUESTION MARK (U+037E) | cdbe
Ϳ | GREEK CAPITAL LETTER YOT (U+037F) | cdbf
΄ | GREEK TONOS (U+0384) | ce84
΅ | GREEK DIALYTIKA TONOS (U+0385) | ce85
Ά | GREEK CAPITAL LETTER ALPHA WITH TONOS (U+0386) | ce86
· | GREEK ANO TELEIA (U+0387) | ce87
Έ | GREEK CAPITAL LETTER EPSILON WITH TONOS (U+0388) | ce88
Ή | GREEK CAPITAL LETTER ETA WITH TONOS (U+0389) | ce89
Ί | GREEK CAPITAL LETTER IOTA WITH TONOS (U+038A) | ce8a
Ό | GREEK CAPITAL LETTER OMICRON WITH TONOS (U+038C) | ce8c
Ύ | GREEK CAPITAL LETTER UPSILON WITH TONOS (U+038E) | ce8e
Ώ | GREEK CAPITAL LETTER OMEGA WITH TONOS (U+038F) | ce8f
ΐ | GREEK SMALL LETTER IOTA WITH DIALYTIKA AND TONOS (U+0390) | ce90
Α | GREEK CAPITAL LETTER ALPHA (U+0391) | ce91
Β | GREEK CAPITAL LETTER BETA (U+0392) | ce92
Γ | GREEK CAPITAL LETTER GAMMA (U+0393) | ce93
Δ | GREEK CAPITAL LETTER DELTA (U+0394) | ce94
Ε | GREEK CAPITAL LETTER EPSILON (U+0395) | ce95
Ζ | GREEK CAPITAL LETTER ZETA (U+0396) | ce96
Η | GREEK CAPITAL LETTER ETA (U+0397) | ce97
Θ | GREEK CAPITAL LETTER THETA (U+0398) | ce98
Ι | GREEK CAPITAL LETTER IOTA (U+0399) | ce99
Κ | GREEK CAPITAL LETTER KAPPA (U+039A) | ce9a
Λ | GREEK CAPITAL LETTER LAMDA (U+039B) | ce9b
Μ | GREEK CAPITAL LETTER MU (U+039C) | ce9c
Ν | GREEK CAPITAL LETTER NU (U+039D) | ce9d
Ξ | GREEK CAPITAL LETTER XI (U+039E) | ce9e
Ο | GREEK CAPITAL LETTER OMICRON (U+039F) | ce9f
Π | GREEK CAPITAL LETTER PI (U+03A0) | cea0
Ρ | GREEK CAPITAL LETTER RHO (U+03A1) | cea1
Σ | GREEK CAPITAL LETTER SIGMA (U+03A3) | cea3
Τ | GREEK CAPITAL LETTER TAU (U+03A4) | cea4
Υ | GREEK CAPITAL LETTER UPSILON (U+03A5) | cea5
Φ | GREEK CAPITAL LETTER PHI (U+03A6) | cea6
Χ | GREEK CAPITAL LETTER CHI (U+03A7) | cea7
Ψ | GREEK CAPITAL LETTER PSI (U+03A8) | cea8
Ω | GREEK CAPITAL LETTER OMEGA (U+03A9) | cea9
Ϊ | GREEK CAPITAL LETTER IOTA WITH DIALYTIKA (U+03AA) | ceaa
Ϋ | GREEK CAPITAL LETTER UPSILON WITH DIALYTIKA (U+03AB) | ceab
ά | GREEK SMALL LETTER ALPHA WITH TONOS (U+03AC) | ceac
έ | GREEK SMALL LETTER EPSILON WITH TONOS (U+03AD) | cead
ή | GREEK SMALL LETTER ETA WITH TONOS (U+03AE) | ceae
ί | GREEK SMALL LETTER IOTA WITH TONOS (U+03AF) | ceaf
ΰ | GREEK SMALL LETTER UPSILON WITH DIALYTIKA AND TONOS (U+03B0) | ceb0
α | GREEK SMALL LETTER ALPHA (U+03B1) | ceb1
β | GREEK SMALL LETTER BETA (U+03B2) | ceb2
γ | GREEK SMALL LETTER GAMMA (U+03B3) | ceb3
δ | GREEK SMALL LETTER DELTA (U+03B4) | ceb4
ε | GREEK SMALL LETTER EPSILON (U+03B5) | ceb5
ζ | GREEK SMALL LETTER ZETA (U+03B6) | ceb6
η | GREEK SMALL LETTER ETA (U+03B7) | ceb7
θ | GREEK SMALL LETTER THETA (U+03B8) | ceb8
ι | GREEK SMALL LETTER IOTA (U+03B9) | ceb9
κ | GREEK SMALL LETTER KAPPA (U+03BA) | ceba
λ | GREEK SMALL LETTER LAMDA (U+03BB) | cebb
μ | GREEK SMALL LETTER MU (U+03BC) | cebc
ν | GREEK SMALL LETTER NU (U+03BD) | cebd
ξ | GREEK SMALL LETTER XI (U+03BE) | cebe
ο | GREEK SMALL LETTER OMICRON (U+03BF) | cebf
π | GREEK SMALL LETTER PI (U+03C0) | cf80
ρ | GREEK SMALL LETTER RHO (U+03C1) | cf81
ς | GREEK SMALL LETTER FINAL SIGMA (U+03C2) | cf82
σ | GREEK SMALL LETTER SIGMA (U+03C3) | cf83
τ | GREEK SMALL LETTER TAU (U+03C4) | cf84
υ | GREEK SMALL LETTER UPSILON (U+03C5) | cf85
φ | GREEK SMALL LETTER PHI (U+03C6) | cf86
χ | GREEK SMALL LETTER CHI (U+03C7) | cf87
ψ | GREEK SMALL LETTER PSI (U+03C8) | cf88
ω | GREEK SMALL LETTER OMEGA (U+03C9) | cf89
ϊ | GREEK SMALL LETTER IOTA WITH DIALYTIKA (U+03CA) | cf8a
ϋ | GREEK SMALL LETTER UPSILON WITH DIALYTIKA (U+03CB) | cf8b
ό | GREEK SMALL LETTER OMICRON WITH TONOS (U+03CC) | cf8c
ύ | GREEK SMALL LETTER UPSILON WITH TONOS (U+03CD) | cf8d
ώ | GREEK SMALL LETTER OMEGA WITH TONOS (U+03CE) | cf8e
Ϗ | GREEK CAPITAL KAI SYMBOL (U+03CF) | cf8f
ϐ | GREEK BETA SYMBOL (U+03D0) | cf90
ϑ | GREEK THETA SYMBOL (U+03D1) | cf91
ϒ | GREEK UPSILON WITH HOOK SYMBOL (U+03D2) | cf92
ϓ | GREEK UPSILON WITH ACUTE AND HOOK SYMBOL (U+03D3) | cf93
ϔ | GREEK UPSILON WITH DIAERESIS AND HOOK SYMBOL (U+03D4) | cf94
ϕ | GREEK PHI SYMBOL (U+03D5) | cf95
ϖ | GREEK PI SYMBOL (U+03D6) | cf96
ϗ | GREEK KAI SYMBOL (U+03D7) | cf97
Ϙ | GREEK LETTER ARCHAIC KOPPA (U+03D8) | cf98
ϙ | GREEK SMALL LETTER ARCHAIC KOPPA (U+03D9) | cf99
Ϛ | GREEK LETTER STIGMA (U+03DA) | cf9a
ϛ | GREEK SMALL LETTER STIGMA (U+03DB) | cf9b
Ϝ | GREEK LETTER DIGAMMA (U+03DC) | cf9c
ϝ | GREEK SMALL LETTER DIGAMMA (U+03DD) | cf9d
Ϟ | GREEK LETTER KOPPA (U+03DE) | cf9e
ϟ | GREEK SMALL LETTER KOPPA (U+03DF) | cf9f
Ϡ | GREEK LETTER SAMPI (U+03E0) | cfa0
ϡ | GREEK SMALL LETTER SAMPI (U+03E1) | cfa1
Ϣ | COPTIC CAPITAL LETTER SHEI (U+03E2) | cfa2
ϣ | COPTIC SMALL LETTER SHEI (U+03E3) | cfa3
Ϥ | COPTIC CAPITAL LETTER FEI (U+03E4) | cfa4
ϥ | COPTIC SMALL LETTER FEI (U+03E5) | cfa5
Ϧ | COPTIC CAPITAL LETTER KHEI (U+03E6) | cfa6
ϧ | COPTIC SMALL LETTER KHEI (U+03E7) | cfa7
Ϩ | COPTIC CAPITAL LETTER HORI (U+03E8) | cfa8
ϩ | COPTIC SMALL LETTER HORI (U+03E9) | cfa9
Ϫ | COPTIC CAPITAL LETTER GANGIA (U+03EA) | cfaa
ϫ | COPTIC SMALL LETTER GANGIA (U+03EB) | cfab
Ϭ | COPTIC CAPITAL LETTER SHIMA (U+03EC) | cfac
ϭ | COPTIC SMALL LETTER SHIMA (U+03ED) | cfad
Ϯ | COPTIC CAPITAL LETTER DEI (U+03EE) | cfae
ϯ | COPTIC SMALL LETTER DEI (U+03EF) | cfaf
ϰ | GREEK KAPPA SYMBOL (U+03F0) | cfb0
ϱ | GREEK RHO SYMBOL (U+03F1) | cfb1
ϲ | GREEK LUNATE SIGMA SYMBOL (U+03F2) | cfb2
ϳ | GREEK LETTER YOT (U+03F3) | cfb3
ϴ | GREEK CAPITAL THETA SYMBOL (U+03F4) | cfb4
ϵ | GREEK LUNATE EPSILON SYMBOL (U+03F5) | cfb5
϶ | GREEK REVERSED LUNATE EPSILON SYMBOL (U+03F6) | cfb6
Ϸ | GREEK CAPITAL LETTER SHO (U+03F7) | cfb7
ϸ | GREEK SMALL LETTER SHO (U+03F8) | cfb8
Ϲ | GREEK CAPITAL LUNATE SIGMA SYMBOL (U+03F9) | cfb9
Ϻ | GREEK CAPITAL LETTER SAN (U+03FA) | cfba
ϻ | GREEK SMALL LETTER SAN (U+03FB) | cfbb
ϼ | GREEK RHO WITH STROKE SYMBOL (U+03FC) | cfbc
Ͻ | GREEK CAPITAL REVERSED LUNATE SIGMA SYMBOL (U+03FD) | cfbd
Ͼ | GREEK CAPITAL DOTTED LUNATE SIGMA SYMBOL (U+03FE) | cfbe
Ͽ | GREEK CAPITAL REVERSED DOTTED LUNATE SIGMA SYMBOL (U+03FF) | cfbf
Ѐ | CYRILLIC CAPITAL LETTER IE WITH GRAVE (U+0400) | d080
Ё | CYRILLIC CAPITAL LETTER IO (U+0401) | d081
Ђ | CYRILLIC CAPITAL LETTER DJE (U+0402) | d082
Ѓ | CYRILLIC CAPITAL LETTER GJE (U+0403) | d083
Є | CYRILLIC CAPITAL LETTER UKRAINIAN IE (U+0404) | d084
Ѕ | CYRILLIC CAPITAL LETTER DZE (U+0405) | d085
І | CYRILLIC CAPITAL LETTER BYELORUSSIAN-UKRAINIAN I (U+0406) | d086
Ї | CYRILLIC CAPITAL LETTER YI (U+0407) | d087
Ј | CYRILLIC CAPITAL LETTER JE (U+0408) | d088
More...



		</div>
	ca83
ʄ 	[LATIN SMALL LETTER DOTLESS J WITH STROKE AND HOOK (U+0284)](https://www.fileformat.info/info/unicode/char/0284/index.htm) 	ca84
ʅ 	[LATIN SMALL LETTER SQUAT REVERSED ESH (U+0285)](https://www.fileformat.info/info/unicode/char/0285/index.htm) 	ca85
ʆ 	[LATIN SMALL LETTER ESH WITH CURL (U+0286)](https://www.fileformat.info/info/unicode/char/0286/index.htm) 	ca86
ʇ 	[LATIN SMALL LETTER TURNED T (U+0287)](https://www.fileformat.info/info/unicode/char/0287/index.htm) 	ca87
ʈ 	[LATIN SMALL LETTER T WITH RETROFLEX HOOK (U+0288)](https://www.fileformat.info/info/unicode/char/0288/index.htm) 	ca88
ʉ 	[LATIN SMALL LETTER U BAR (U+0289)](https://www.fileformat.info/info/unicode/char/0289/index.htm) 	ca89
ʊ 	[LATIN SMALL LETTER UPSILON (U+028A)](https://www.fileformat.info/info/unicode/char/028a/index.htm) 	ca8a
ʋ 	[LATIN SMALL LETTER V WITH HOOK (U+028B)](https://www.fileformat.info/info/unicode/char/028b/index.htm) 	ca8b
ʌ 	[LATIN SMALL LETTER TURNED V (U+028C)](https://www.fileformat.info/info/unicode/char/028c/index.htm) 	ca8c
ʍ 	[LATIN SMALL LETTER TURNED W (U+028D)](https://www.fileformat.info/info/unicode/char/028d/index.htm) 	ca8d
ʎ 	[LATIN SMALL LETTER TURNED Y (U+028E)](https://www.fileformat.info/info/unicode/char/028e/index.htm) 	ca8e
ʏ 	[LATIN LETTER SMALL CAPITAL Y (U+028F)](https://www.fileformat.info/info/unicode/char/028f/index.htm) 	ca8f
ʐ 	[LATIN SMALL LETTER Z WITH RETROFLEX HOOK (U+0290)](https://www.fileformat.info/info/unicode/char/0290/index.htm) 	ca90
ʑ 	[LATIN SMALL LETTER Z WITH CURL (U+0291)](https://www.fileformat.info/info/unicode/char/0291/index.htm) 	ca91
ʒ 	[LATIN SMALL LETTER EZH (U+0292)](https://www.fileformat.info/info/unicode/char/0292/index.htm) 	ca92
ʓ 	[LATIN SMALL LETTER EZH WITH CURL (U+0293)](https://www.fileformat.info/info/unicode/char/0293/index.htm) 	ca93
ʔ 	[LATIN LETTER GLOTTAL STOP (U+0294)](https://www.fileformat.info/info/unicode/char/0294/index.htm) 	ca94
ʕ 	[LATIN LETTER PHARYNGEAL VOICED FRICATIVE (U+0295)](https://www.fileformat.info/info/unicode/char/0295/index.htm) 	ca95
ʖ 	[LATIN LETTER INVERTED GLOTTAL STOP (U+0296)](https://www.fileformat.info/info/unicode/char/0296/index.htm) 	ca96
ʗ 	[LATIN LETTER STRETCHED C (U+0297)](https://www.fileformat.info/info/unicode/char/0297/index.htm) 	ca97
ʘ 	[LATIN LETTER BILABIAL CLICK (U+0298)](https://www.fileformat.info/info/unicode/char/0298/index.htm) 	ca98
ʙ 	[LATIN LETTER SMALL CAPITAL B (U+0299)](https://www.fileformat.info/info/unicode/char/0299/index.htm) 	ca99
ʚ 	[LATIN SMALL LETTER CLOSED OPEN E (U+029A)](https://www.fileformat.info/info/unicode/char/029a/index.htm) 	ca9a
ʛ 	[LATIN LETTER SMALL CAPITAL G WITH HOOK (U+029B)](https://www.fileformat.info/info/unicode/char/029b/index.htm) 	ca9b
ʜ 	[LATIN LETTER SMALL CAPITAL H (U+029C)](https://www.fileformat.info/info/unicode/char/029c/index.htm) 	ca9c
ʝ 	[LATIN SMALL LETTER J WITH CROSSED-TAIL (U+029D)](https://www.fileformat.info/info/unicode/char/029d/index.htm) 	ca9d
ʞ 	[LATIN SMALL LETTER TURNED K (U+029E)](https://www.fileformat.info/info/unicode/char/029e/index.htm) 	ca9e
ʟ 	[LATIN LETTER SMALL CAPITAL L (U+029F)](https://www.fileformat.info/info/unicode/char/029f/index.htm) 	ca9f
ʠ 	[LATIN SMALL LETTER Q WITH HOOK (U+02A0)](https://www.fileformat.info/info/unicode/char/02a0/index.htm) 	caa0
ʡ 	[LATIN LETTER GLOTTAL STOP WITH STROKE (U+02A1)](https://www.fileformat.info/info/unicode/char/02a1/index.htm) 	caa1
ʢ 	[LATIN LETTER REVERSED GLOTTAL STOP WITH STROKE (U+02A2)](https://www.fileformat.info/info/unicode/char/02a2/index.htm) 	caa2
ʣ 	[LATIN SMALL LETTER DZ DIGRAPH (U+02A3)](https://www.fileformat.info/info/unicode/char/02a3/index.htm) 	caa3
ʤ 	[LATIN SMALL LETTER DEZH DIGRAPH (U+02A4)](https://www.fileformat.info/info/unicode/char/02a4/index.htm) 	caa4
ʥ 	[LATIN SMALL LETTER DZ DIGRAPH WITH CURL (U+02A5)](https://www.fileformat.info/info/unicode/char/02a5/index.htm) 	caa5
ʦ 	[LATIN SMALL LETTER TS DIGRAPH (U+02A6)](https://www.fileformat.info/info/unicode/char/02a6/index.htm) 	caa6
ʧ 	[LATIN SMALL LETTER TESH DIGRAPH (U+02A7)](https://www.fileformat.info/info/unicode/char/02a7/index.htm) 	caa7
ʨ 	[LATIN SMALL LETTER TC DIGRAPH WITH CURL (U+02A8)](https://www.fileformat.info/info/unicode/char/02a8/index.htm) 	caa8
ʩ 	[LATIN SMALL LETTER FENG DIGRAPH (U+02A9)](https://www.fileformat.info/info/unicode/char/02a9/index.htm) 	caa9
ʪ 	[LATIN SMALL LETTER LS DIGRAPH (U+02AA)](https://www.fileformat.info/info/unicode/char/02aa/index.htm) 	caaa
ʫ 	[LATIN SMALL LETTER LZ DIGRAPH (U+02AB)](https://www.fileformat.info/info/unicode/char/02ab/index.htm) 	caab
ʬ 	[LATIN LETTER BILABIAL PERCUSSIVE (U+02AC)](https://www.fileformat.info/info/unicode/char/02ac/index.htm) 	caac
ʭ 	[LATIN LETTER BIDENTAL PERCUSSIVE (U+02AD)](https://www.fileformat.info/info/unicode/char/02ad/index.htm) 	caad
ʮ 	[LATIN SMALL LETTER TURNED H WITH FISHHOOK (U+02AE)](https://www.fileformat.info/info/unicode/char/02ae/index.htm) 	caae
ʯ 	[LATIN SMALL LETTER TURNED H WITH FISHHOOK AND TAIL (U+02AF)](https://www.fileformat.info/info/unicode/char/02af/index.htm) 	caaf
ʰ 	[MODIFIER LETTER SMALL H (U+02B0)](https://www.fileformat.info/info/unicode/char/02b0/index.htm) 	cab0
ʱ 	[MODIFIER LETTER SMALL H WITH HOOK (U+02B1)](https://www.fileformat.info/info/unicode/char/02b1/index.htm) 	cab1
ʲ 	[MODIFIER LETTER SMALL J (U+02B2)](https://www.fileformat.info/info/unicode/char/02b2/index.htm) 	cab2
ʳ 	[MODIFIER LETTER SMALL R (U+02B3)](https://www.fileformat.info/info/unicode/char/02b3/index.htm) 	cab3
ʴ 	[MODIFIER LETTER SMALL TURNED R (U+02B4)](https://www.fileformat.info/info/unicode/char/02b4/index.htm) 	cab4
ʵ 	[MODIFIER LETTER SMALL TURNED R WITH HOOK (U+02B5)](https://www.fileformat.info/info/unicode/char/02b5/index.htm) 	cab5
ʶ 	[MODIFIER LETTER SMALL CAPITAL INVERTED R (U+02B6)](https://www.fileformat.info/info/unicode/char/02b6/index.htm) 	cab6
ʷ 	[MODIFIER LETTER SMALL W (U+02B7)](https://www.fileformat.info/info/unicode/char/02b7/index.htm) 	cab7
ʸ 	[MODIFIER LETTER SMALL Y (U+02B8)](https://www.fileformat.info/info/unicode/char/02b8/index.htm) 	cab8
ʹ 	[MODIFIER LETTER PRIME (U+02B9)](https://www.fileformat.info/info/unicode/char/02b9/index.htm) 	cab9
ʺ 	[MODIFIER LETTER DOUBLE PRIME (U+02BA)](https://www.fileformat.info/info/unicode/char/02ba/index.htm) 	caba
ʻ 	[MODIFIER LETTER TURNED COMMA (U+02BB)](https://www.fileformat.info/info/unicode/char/02bb/index.htm) 	cabb
ʼ 	[MODIFIER LETTER APOSTROPHE (U+02BC)](https://www.fileformat.info/info/unicode/char/02bc/index.htm) 	cabc
ʽ 	[MODIFIER LETTER REVERSED COMMA (U+02BD)](https://www.fileformat.info/info/unicode/char/02bd/index.htm) 	cabd
ʾ 	[MODIFIER LETTER RIGHT HALF RING (U+02BE)](https://www.fileformat.info/info/unicode/char/02be/index.htm) 	cabe
ʿ 	[MODIFIER LETTER LEFT HALF RING (U+02BF)](https://www.fileformat.info/info/unicode/char/02bf/index.htm) 	cabf
ˀ 	[MODIFIER LETTER GLOTTAL STOP (U+02C0)](https://www.fileformat.info/info/unicode/char/02c0/index.htm) 	cb80
ˁ 	[MODIFIER LETTER REVERSED GLOTTAL STOP (U+02C1)](https://www.fileformat.info/info/unicode/char/02c1/index.htm) 	cb81
˂ 	[MODIFIER LETTER LEFT ARROWHEAD (U+02C2)](https://www.fileformat.info/info/unicode/char/02c2/index.htm) 	cb82
˃ 	[MODIFIER LETTER RIGHT ARROWHEAD (U+02C3)](https://www.fileformat.info/info/unicode/char/02c3/index.htm) 	cb83
˄ 	[MODIFIER LETTER UP ARROWHEAD (U+02C4)](https://www.fileformat.info/info/unicode/char/02c4/index.htm) 	cb84
˅ 	[MODIFIER LETTER DOWN ARROWHEAD (U+02C5)](https://www.fileformat.info/info/unicode/char/02c5/index.htm) 	cb85
ˆ 	[MODIFIER LETTER CIRCUMFLEX ACCENT (U+02C6)](https://www.fileformat.info/info/unicode/char/02c6/index.htm) 	cb86
ˇ 	[CARON (U+02C7)](https://www.fileformat.info/info/unicode/char/02c7/index.htm) 	cb87
ˈ 	[MODIFIER LETTER VERTICAL LINE (U+02C8)](https://www.fileformat.info/info/unicode/char/02c8/index.htm) 	cb88
ˉ 	[MODIFIER LETTER MACRON (U+02C9)](https://www.fileformat.info/info/unicode/char/02c9/index.htm) 	cb89
ˊ 	[MODIFIER LETTER ACUTE ACCENT (U+02CA)](https://www.fileformat.info/info/unicode/char/02ca/index.htm) 	cb8a
ˋ 	[MODIFIER LETTER GRAVE ACCENT (U+02CB)](https://www.fileformat.info/info/unicode/char/02cb/index.htm) 	cb8b
ˌ 	[MODIFIER LETTER LOW VERTICAL LINE (U+02CC)](https://www.fileformat.info/info/unicode/char/02cc/index.htm) 	cb8c
ˍ 	[MODIFIER LETTER LOW MACRON (U+02CD)](https://www.fileformat.info/info/unicode/char/02cd/index.htm) 	cb8d
ˎ 	[MODIFIER LETTER LOW GRAVE ACCENT (U+02CE)](https://www.fileformat.info/info/unicode/char/02ce/index.htm) 	cb8e
ˏ 	[MODIFIER LETTER LOW ACUTE ACCENT (U+02CF)](https://www.fileformat.info/info/unicode/char/02cf/index.htm) 	cb8f
ː 	[MODIFIER LETTER TRIANGULAR COLON (U+02D0)](https://www.fileformat.info/info/unicode/char/02d0/index.htm) 	cb90
ˑ 	[MODIFIER LETTER HALF TRIANGULAR COLON (U+02D1)](https://www.fileformat.info/info/unicode/char/02d1/index.htm) 	cb91
˒ 	[MODIFIER LETTER CENTRED RIGHT HALF RING (U+02D2)](https://www.fileformat.info/info/unicode/char/02d2/index.htm) 	cb92
˓ 	[MODIFIER LETTER CENTRED LEFT HALF RING (U+02D3)](https://www.fileformat.info/info/unicode/char/02d3/index.htm) 	cb93
˔ 	[MODIFIER LETTER UP TACK (U+02D4)](https://www.fileformat.info/info/unicode/char/02d4/index.htm) 	cb94
˕ 	[MODIFIER LETTER DOWN TACK (U+02D5)](https://www.fileformat.info/info/unicode/char/02d5/index.htm) 	cb95
˖ 	[MODIFIER LETTER PLUS SIGN (U+02D6)](https://www.fileformat.info/info/unicode/char/02d6/index.htm) 	cb96
˗ 	[MODIFIER LETTER MINUS SIGN (U+02D7)](https://www.fileformat.info/info/unicode/char/02d7/index.htm) 	cb97
˘ 	[BREVE (U+02D8)](https://www.fileformat.info/info/unicode/char/02d8/index.htm) 	cb98
˙ 	[DOT ABOVE (U+02D9)](https://www.fileformat.info/info/unicode/char/02d9/index.htm) 	cb99
˚ 	[RING ABOVE (U+02DA)](https://www.fileformat.info/info/unicode/char/02da/index.htm) 	cb9a
˛ 	[OGONEK (U+02DB)](https://www.fileformat.info/info/unicode/char/02db/index.htm) 	cb9b
˜ 	[SMALL TILDE (U+02DC)](https://www.fileformat.info/info/unicode/char/02dc/index.htm) 	cb9c
˝ 	[DOUBLE ACUTE ACCENT (U+02DD)](https://www.fileformat.info/info/unicode/char/02dd/index.htm) 	cb9d
˞ 	[MODIFIER LETTER RHOTIC HOOK (U+02DE)](https://www.fileformat.info/info/unicode/char/02de/index.htm) 	cb9e
˟ 	[MODIFIER LETTER CROSS ACCENT (U+02DF)](https://www.fileformat.info/info/unicode/char/02df/index.htm) 	cb9f
ˠ 	[MODIFIER LETTER SMALL GAMMA (U+02E0)](https://www.fileformat.info/info/unicode/char/02e0/index.htm) 	cba0
ˡ 	[MODIFIER LETTER SMALL L (U+02E1)](https://www.fileformat.info/info/unicode/char/02e1/index.htm) 	cba1
ˢ 	[MODIFIER LETTER SMALL S (U+02E2)](https://www.fileformat.info/info/unicode/char/02e2/index.htm) 	cba2
ˣ 	[MODIFIER LETTER SMALL X (U+02E3)](https://www.fileformat.info/info/unicode/char/02e3/index.htm) 	cba3
ˤ 	[MODIFIER LETTER SMALL REVERSED GLOTTAL STOP (U+02E4)](https://www.fileformat.info/info/unicode/char/02e4/index.htm) 	cba4
˥ 	[MODIFIER LETTER EXTRA-HIGH TONE BAR (U+02E5)](https://www.fileformat.info/info/unicode/char/02e5/index.htm) 	cba5
˦ 	[MODIFIER LETTER HIGH TONE BAR (U+02E6)](https://www.fileformat.info/info/unicode/char/02e6/index.htm) 	cba6
˧ 	[MODIFIER LETTER MID TONE BAR (U+02E7)](https://www.fileformat.info/info/unicode/char/02e7/index.htm) 	cba7
˨ 	[MODIFIER LETTER LOW TONE BAR (U+02E8)](https://www.fileformat.info/info/unicode/char/02e8/index.htm) 	cba8
˩ 	[MODIFIER LETTER EXTRA-LOW TONE BAR (U+02E9)](https://www.fileformat.info/info/unicode/char/02e9/index.htm) 	cba9
˪ 	[MODIFIER LETTER YIN DEPARTING TONE MARK (U+02EA)](https://www.fileformat.info/info/unicode/char/02ea/index.htm) 	cbaa
˫ 	[MODIFIER LETTER YANG DEPARTING TONE MARK (U+02EB)](https://www.fileformat.info/info/unicode/char/02eb/index.htm) 	cbab
ˬ 	[MODIFIER LETTER VOICING (U+02EC)](https://www.fileformat.info/info/unicode/char/02ec/index.htm) 	cbac
˭ 	[MODIFIER LETTER UNASPIRATED (U+02ED)](https://www.fileformat.info/info/unicode/char/02ed/index.htm) 	cbad
ˮ 	[MODIFIER LETTER DOUBLE APOSTROPHE (U+02EE)](https://www.fileformat.info/info/unicode/char/02ee/index.htm) 	cbae
˯ 	[MODIFIER LETTER LOW DOWN ARROWHEAD (U+02EF)](https://www.fileformat.info/info/unicode/char/02ef/index.htm) 	cbaf
˰ 	[MODIFIER LETTER LOW UP ARROWHEAD (U+02F0)](https://www.fileformat.info/info/unicode/char/02f0/index.htm) 	cbb0
˱ 	[MODIFIER LETTER LOW LEFT ARROWHEAD (U+02F1)](https://www.fileformat.info/info/unicode/char/02f1/index.htm) 	cbb1
˲ 	[MODIFIER LETTER LOW RIGHT ARROWHEAD (U+02F2)](https://www.fileformat.info/info/unicode/char/02f2/index.htm) 	cbb2
˳ 	[MODIFIER LETTER LOW RING (U+02F3)](https://www.fileformat.info/info/unicode/char/02f3/index.htm) 	cbb3
˴ 	[MODIFIER LETTER MIDDLE GRAVE ACCENT (U+02F4)](https://www.fileformat.info/info/unicode/char/02f4/index.htm) 	cbb4
˵ 	[MODIFIER LETTER MIDDLE DOUBLE GRAVE ACCENT (U+02F5)](https://www.fileformat.info/info/unicode/char/02f5/index.htm) 	cbb5
˶ 	[MODIFIER LETTER MIDDLE DOUBLE ACUTE ACCENT (U+02F6)](https://www.fileformat.info/info/unicode/char/02f6/index.htm) 	cbb6
˷ 	[MODIFIER LETTER LOW TILDE (U+02F7)](https://www.fileformat.info/info/unicode/char/02f7/index.htm) 	cbb7
˸ 	[MODIFIER LETTER RAISED COLON (U+02F8)](https://www.fileformat.info/info/unicode/char/02f8/index.htm) 	cbb8
˹ 	[MODIFIER LETTER BEGIN HIGH TONE (U+02F9)](https://www.fileformat.info/info/unicode/char/02f9/index.htm) 	cbb9
˺ 	[MODIFIER LETTER END HIGH TONE (U+02FA)](https://www.fileformat.info/info/unicode/char/02fa/index.htm) 	cbba
˻ 	[MODIFIER LETTER BEGIN LOW TONE (U+02FB)](https://www.fileformat.info/info/unicode/char/02fb/index.htm) 	cbbb
˼ 	[MODIFIER LETTER END LOW TONE (U+02FC)](https://www.fileformat.info/info/unicode/char/02fc/index.htm) 	cbbc
˽ 	[MODIFIER LETTER SHELF (U+02FD)](https://www.fileformat.info/info/unicode/char/02fd/index.htm) 	cbbd
˾ 	[MODIFIER LETTER OPEN SHELF (U+02FE)](https://www.fileformat.info/info/unicode/char/02fe/index.htm) 	cbbe
˿ 	[MODIFIER LETTER LOW LEFT ARROW (U+02FF)](https://www.fileformat.info/info/unicode/char/02ff/index.htm) 	cbbf
̀ 	[COMBINING GRAVE ACCENT (U+0300)](https://www.fileformat.info/info/unicode/char/0300/index.htm) 	cc80
́ 	[COMBINING ACUTE ACCENT (U+0301)](https://www.fileformat.info/info/unicode/char/0301/index.htm) 	cc81
̂ 	[COMBINING CIRCUMFLEX ACCENT (U+0302)](https://www.fileformat.info/info/unicode/char/0302/index.htm) 	cc82
̃ 	[COMBINING TILDE (U+0303)](https://www.fileformat.info/info/unicode/char/0303/index.htm) 	cc83
̄ 	[COMBINING MACRON (U+0304)](https://www.fileformat.info/info/unicode/char/0304/index.htm) 	cc84
̅ 	[COMBINING OVERLINE (U+0305)](https://www.fileformat.info/info/unicode/char/0305/index.htm) 	cc85
̆ 	[COMBINING BREVE (U+0306)](https://www.fileformat.info/info/unicode/char/0306/index.htm) 	cc86
̇ 	[COMBINING DOT ABOVE (U+0307)](https://www.fileformat.info/info/unicode/char/0307/index.htm) 	cc87
̈ 	[COMBINING DIAERESIS (U+0308)](https://www.fileformat.info/info/unicode/char/0308/index.htm) 	cc88
̉ 	[COMBINING HOOK ABOVE (U+0309)](https://www.fileformat.info/info/unicode/char/0309/index.htm) 	cc89
̊ 	[COMBINING RING ABOVE (U+030A)](https://www.fileformat.info/info/unicode/char/030a/index.htm) 	cc8a
̋ 	[COMBINING DOUBLE ACUTE ACCENT (U+030B)](https://www.fileformat.info/info/unicode/char/030b/index.htm) 	cc8b
̌ 	[COMBINING CARON (U+030C)](https://www.fileformat.info/info/unicode/char/030c/index.htm) 	cc8c
̍ 	[COMBINING VERTICAL LINE ABOVE (U+030D)](https://www.fileformat.info/info/unicode/char/030d/index.htm) 	cc8d
̎ 	[COMBINING DOUBLE VERTICAL LINE ABOVE (U+030E)](https://www.fileformat.info/info/unicode/char/030e/index.htm) 	cc8e
̏ 	[COMBINING DOUBLE GRAVE ACCENT (U+030F)](https://www.fileformat.info/info/unicode/char/030f/index.htm) 	cc8f
̐ 	[COMBINING CANDRABINDU (U+0310)](https://www.fileformat.info/info/unicode/char/0310/index.htm) 	cc90
̑ 	[COMBINING INVERTED BREVE (U+0311)](https://www.fileformat.info/info/unicode/char/0311/index.htm) 	cc91
̒ 	[COMBINING TURNED COMMA ABOVE (U+0312)](https://www.fileformat.info/info/unicode/char/0312/index.htm) 	cc92
̓ 	[COMBINING COMMA ABOVE (U+0313)](https://www.fileformat.info/info/unicode/char/0313/index.htm) 	cc93
̔ 	[COMBINING REVERSED COMMA ABOVE (U+0314)](https://www.fileformat.info/info/unicode/char/0314/index.htm) 	cc94
̕ 	[COMBINING COMMA ABOVE RIGHT (U+0315)](https://www.fileformat.info/info/unicode/char/0315/index.htm) 	cc95
̖ 	[COMBINING GRAVE ACCENT BELOW (U+0316)](https://www.fileformat.info/info/unicode/char/0316/index.htm) 	cc96
̗ 	[COMBINING ACUTE ACCENT BELOW (U+0317)](https://www.fileformat.info/info/unicode/char/0317/index.htm) 	cc97
̘ 	[COMBINING LEFT TACK BELOW (U+0318)](https://www.fileformat.info/info/unicode/char/0318/index.htm) 	cc98
̙ 	[COMBINING RIGHT TACK BELOW (U+0319)](https://www.fileformat.info/info/unicode/char/0319/index.htm) 	cc99
̚ 	[COMBINING LEFT ANGLE ABOVE (U+031A)](https://www.fileformat.info/info/unicode/char/031a/index.htm) 	cc9a
̛ 	[COMBINING HORN (U+031B)](https://www.fileformat.info/info/unicode/char/031b/index.htm) 	cc9b
̜ 	[COMBINING LEFT HALF RING BELOW (U+031C)](https://www.fileformat.info/info/unicode/char/031c/index.htm) 	cc9c
̝ 	[COMBINING UP TACK BELOW (U+031D)](https://www.fileformat.info/info/unicode/char/031d/index.htm) 	cc9d
̞ 	[COMBINING DOWN TACK BELOW (U+031E)](https://www.fileformat.info/info/unicode/char/031e/index.htm) 	cc9e
̟ 	[COMBINING PLUS SIGN BELOW (U+031F)](https://www.fileformat.info/info/unicode/char/031f/index.htm) 	cc9f
̠ 	[COMBINING MINUS SIGN BELOW (U+0320)](https://www.fileformat.info/info/unicode/char/0320/index.htm) 	cca0
̡ 	[COMBINING PALATALIZED HOOK BELOW (U+0321)](https://www.fileformat.info/info/unicode/char/0321/index.htm) 	cca1
̢ 	[COMBINING RETROFLEX HOOK BELOW (U+0322)](https://www.fileformat.info/info/unicode/char/0322/index.htm) 	cca2
̣ 	[COMBINING DOT BELOW (U+0323)](https://www.fileformat.info/info/unicode/char/0323/index.htm) 	cca3
̤ 	[COMBINING DIAERESIS BELOW (U+0324)](https://www.fileformat.info/info/unicode/char/0324/index.htm) 	cca4
̥ 	[COMBINING RING BELOW (U+0325)](https://www.fileformat.info/info/unicode/char/0325/index.htm) 	cca5
̦ 	[COMBINING COMMA BELOW (U+0326)](https://www.fileformat.info/info/unicode/char/0326/index.htm) 	cca6
̧ 	[COMBINING CEDILLA (U+0327)](https://www.fileformat.info/info/unicode/char/0327/index.htm) 	cca7
̨ 	[COMBINING OGONEK (U+0328)](https://www.fileformat.info/info/unicode/char/0328/index.htm) 	cca8
̩ 	[COMBINING VERTICAL LINE BELOW (U+0329)](https://www.fileformat.info/info/unicode/char/0329/index.htm) 	cca9
̪ 	[COMBINING BRIDGE BELOW (U+032A)](https://www.fileformat.info/info/unicode/char/032a/index.htm) 	ccaa
̫ 	[COMBINING INVERTED DOUBLE ARCH BELOW (U+032B)](https://www.fileformat.info/info/unicode/char/032b/index.htm) 	ccab
̬ 	[COMBINING CARON BELOW (U+032C)](https://www.fileformat.info/info/unicode/char/032c/index.htm) 	ccac
̭ 	[COMBINING CIRCUMFLEX ACCENT BELOW (U+032D)](https://www.fileformat.info/info/unicode/char/032d/index.htm) 	ccad
̮ 	[COMBINING BREVE BELOW (U+032E)](https://www.fileformat.info/info/unicode/char/032e/index.htm) 	ccae
̯ 	[COMBINING INVERTED BREVE BELOW (U+032F)](https://www.fileformat.info/info/unicode/char/032f/index.htm) 	ccaf
̰ 	[COMBINING TILDE BELOW (U+0330)](https://www.fileformat.info/info/unicode/char/0330/index.htm) 	ccb0
̱ 	[COMBINING MACRON BELOW (U+0331)](https://www.fileformat.info/info/unicode/char/0331/index.htm) 	ccb1
̲ 	[COMBINING LOW LINE (U+0332)](https://www.fileformat.info/info/unicode/char/0332/index.htm) 	ccb2
̳ 	[COMBINING DOUBLE LOW LINE (U+0333)](https://www.fileformat.info/info/unicode/char/0333/index.htm) 	ccb3
̴ 	[COMBINING TILDE OVERLAY (U+0334)](https://www.fileformat.info/info/unicode/char/0334/index.htm) 	ccb4
̵ 	[COMBINING SHORT STROKE OVERLAY (U+0335)](https://www.fileformat.info/info/unicode/char/0335/index.htm) 	ccb5
̶ 	[COMBINING LONG STROKE OVERLAY (U+0336)](https://www.fileformat.info/info/unicode/char/0336/index.htm) 	ccb6
̷ 	[COMBINING SHORT SOLIDUS OVERLAY (U+0337)](https://www.fileformat.info/info/unicode/char/0337/index.htm) 	ccb7
̸ 	[COMBINING LONG SOLIDUS OVERLAY (U+0338)](https://www.fileformat.info/info/unicode/char/0338/index.htm) 	ccb8
̹ 	[COMBINING RIGHT HALF RING BELOW (U+0339)](https://www.fileformat.info/info/unicode/char/0339/index.htm) 	ccb9
̺ 	[COMBINING INVERTED BRIDGE BELOW (U+033A)](https://www.fileformat.info/info/unicode/char/033a/index.htm) 	ccba
̻ 	[COMBINING SQUARE BELOW (U+033B)](https://www.fileformat.info/info/unicode/char/033b/index.htm) 	ccbb
̼ 	[COMBINING SEAGULL BELOW (U+033C)](https://www.fileformat.info/info/unicode/char/033c/index.htm) 	ccbc
̽ 	[COMBINING X ABOVE (U+033D)](https://www.fileformat.info/info/unicode/char/033d/index.htm) 	ccbd
̾ 	[COMBINING VERTICAL TILDE (U+033E)](https://www.fileformat.info/info/unicode/char/033e/index.htm) 	ccbe
̿ 	[COMBINING DOUBLE OVERLINE (U+033F)](https://www.fileformat.info/info/unicode/char/033f/index.htm) 	ccbf
̀ 	[COMBINING GRAVE TONE MARK (U+0340)](https://www.fileformat.info/info/unicode/char/0340/index.htm) 	cd80
́ 	[COMBINING ACUTE TONE MARK (U+0341)](https://www.fileformat.info/info/unicode/char/0341/index.htm) 	cd81
͂ 	[COMBINING GREEK PERISPOMENI (U+0342)](https://www.fileformat.info/info/unicode/char/0342/index.htm) 	cd82
̓ 	[COMBINING GREEK KORONIS (U+0343)](https://www.fileformat.info/info/unicode/char/0343/index.htm) 	cd83
̈́ 	[COMBINING GREEK DIALYTIKA TONOS (U+0344)](https://www.fileformat.info/info/unicode/char/0344/index.htm) 	cd84
ͅ 	[COMBINING GREEK YPOGEGRAMMENI (U+0345)](https://www.fileformat.info/info/unicode/char/0345/index.htm) 	cd85
͆ 	[COMBINING BRIDGE ABOVE (U+0346)](https://www.fileformat.info/info/unicode/char/0346/index.htm) 	cd86
͇ 	[COMBINING EQUALS SIGN BELOW (U+0347)](https://www.fileformat.info/info/unicode/char/0347/index.htm) 	cd87
͈ 	[COMBINING DOUBLE VERTICAL LINE BELOW (U+0348)](https://www.fileformat.info/info/unicode/char/0348/index.htm) 	cd88
͉ 	[COMBINING LEFT ANGLE BELOW (U+0349)](https://www.fileformat.info/info/unicode/char/0349/index.htm) 	cd89
͊ 	[COMBINING NOT TILDE ABOVE (U+034A)](https://www.fileformat.info/info/unicode/char/034a/index.htm) 	cd8a
͋ 	[COMBINING HOMOTHETIC ABOVE (U+034B)](https://www.fileformat.info/info/unicode/char/034b/index.htm) 	cd8b
͌ 	[COMBINING ALMOST EQUAL TO ABOVE (U+034C)](https://www.fileformat.info/info/unicode/char/034c/index.htm) 	cd8c
͍ 	[COMBINING LEFT RIGHT ARROW BELOW (U+034D)](https://www.fileformat.info/info/unicode/char/034d/index.htm) 	cd8d
͎ 	[COMBINING UPWARDS ARROW BELOW (U+034E)](https://www.fileformat.info/info/unicode/char/034e/index.htm) 	cd8e
͏ 	[COMBINING GRAPHEME JOINER (U+034F)](https://www.fileformat.info/info/unicode/char/034f/index.htm) 	cd8f
͐ 	[COMBINING RIGHT ARROWHEAD ABOVE (U+0350)](https://www.fileformat.info/info/unicode/char/0350/index.htm) 	cd90
͑ 	[COMBINING LEFT HALF RING ABOVE (U+0351)](https://www.fileformat.info/info/unicode/char/0351/index.htm) 	cd91
͒ 	[COMBINING FERMATA (U+0352)](https://www.fileformat.info/info/unicode/char/0352/index.htm) 	cd92
͓ 	[COMBINING X BELOW (U+0353)](https://www.fileformat.info/info/unicode/char/0353/index.htm) 	cd93
͔ 	[COMBINING LEFT ARROWHEAD BELOW (U+0354)](https://www.fileformat.info/info/unicode/char/0354/index.htm) 	cd94
͕ 	[COMBINING RIGHT ARROWHEAD BELOW (U+0355)](https://www.fileformat.info/info/unicode/char/0355/index.htm) 	cd95
͖ 	[COMBINING RIGHT ARROWHEAD AND UP ARROWHEAD BELOW (U+0356)](https://www.fileformat.info/info/unicode/char/0356/index.htm) 	cd96
͗ 	[COMBINING RIGHT HALF RING ABOVE (U+0357)](https://www.fileformat.info/info/unicode/char/0357/index.htm) 	cd97
͘ 	[COMBINING DOT ABOVE RIGHT (U+0358)](https://www.fileformat.info/info/unicode/char/0358/index.htm) 	cd98
͙ 	[COMBINING ASTERISK BELOW (U+0359)](https://www.fileformat.info/info/unicode/char/0359/index.htm) 	cd99
͚ 	[COMBINING DOUBLE RING BELOW (U+035A)](https://www.fileformat.info/info/unicode/char/035a/index.htm) 	cd9a
͛ 	[COMBINING ZIGZAG ABOVE (U+035B)](https://www.fileformat.info/info/unicode/char/035b/index.htm) 	cd9b
͜ 	[COMBINING DOUBLE BREVE BELOW (U+035C)](https://www.fileformat.info/info/unicode/char/035c/index.htm) 	cd9c
͝ 	[COMBINING DOUBLE BREVE (U+035D)](https://www.fileformat.info/info/unicode/char/035d/index.htm) 	cd9d
͞ 	[COMBINING DOUBLE MACRON (U+035E)](https://www.fileformat.info/info/unicode/char/035e/index.htm) 	cd9e
͟ 	[COMBINING DOUBLE MACRON BELOW (U+035F)](https://www.fileformat.info/info/unicode/char/035f/index.htm) 	cd9f
͠ 	[COMBINING DOUBLE TILDE (U+0360)](https://www.fileformat.info/info/unicode/char/0360/index.htm) 	cda0
͡ 	[COMBINING DOUBLE INVERTED BREVE (U+0361)](https://www.fileformat.info/info/unicode/char/0361/index.htm) 	cda1
͢ 	[COMBINING DOUBLE RIGHTWARDS ARROW BELOW (U+0362)](https://www.fileformat.info/info/unicode/char/0362/index.htm) 	cda2
ͣ 	[COMBINING LATIN SMALL LETTER A (U+0363)](https://www.fileformat.info/info/unicode/char/0363/index.htm) 	cda3
ͤ 	[COMBINING LATIN SMALL LETTER E (U+0364)](https://www.fileformat.info/info/unicode/char/0364/index.htm) 	cda4
ͥ 	[COMBINING LATIN SMALL LETTER I (U+0365)](https://www.fileformat.info/info/unicode/char/0365/index.htm) 	cda5
ͦ 	[COMBINING LATIN SMALL LETTER O (U+0366)](https://www.fileformat.info/info/unicode/char/0366/index.htm) 	cda6
ͧ 	[COMBINING LATIN SMALL LETTER U (U+0367)](https://www.fileformat.info/info/unicode/char/0367/index.htm) 	cda7
ͨ 	[COMBINING LATIN SMALL LETTER C (U+0368)](https://www.fileformat.info/info/unicode/char/0368/index.htm) 	cda8
ͩ 	[COMBINING LATIN SMALL LETTER D (U+0369)](https://www.fileformat.info/info/unicode/char/0369/index.htm) 	cda9
ͪ 	[COMBINING LATIN SMALL LETTER H (U+036A)](https://www.fileformat.info/info/unicode/char/036a/index.htm) 	cdaa
ͫ 	[COMBINING LATIN SMALL LETTER M (U+036B)](https://www.fileformat.info/info/unicode/char/036b/index.htm) 	cdab
ͬ 	[COMBINING LATIN SMALL LETTER R (U+036C)](https://www.fileformat.info/info/unicode/char/036c/index.htm) 	cdac
ͭ 	[COMBINING LATIN SMALL LETTER T (U+036D)](https://www.fileformat.info/info/unicode/char/036d/index.htm) 	cdad
ͮ 	[COMBINING LATIN SMALL LETTER V (U+036E)](https://www.fileformat.info/info/unicode/char/036e/index.htm) 	cdae
ͯ 	[COMBINING LATIN SMALL LETTER X (U+036F)](https://www.fileformat.info/info/unicode/char/036f/index.htm) 	cdaf
Ͱ 	[GREEK CAPITAL LETTER HETA (U+0370)](https://www.fileformat.info/info/unicode/char/0370/index.htm) 	cdb0
ͱ 	[GREEK SMALL LETTER HETA (U+0371)](https://www.fileformat.info/info/unicode/char/0371/index.htm) 	cdb1
Ͳ 	[GREEK CAPITAL LETTER ARCHAIC SAMPI (U+0372)](https://www.fileformat.info/info/unicode/char/0372/index.htm) 	cdb2
ͳ 	[GREEK SMALL LETTER ARCHAIC SAMPI (U+0373)](https://www.fileformat.info/info/unicode/char/0373/index.htm) 	cdb3
ʹ 	[GREEK NUMERAL SIGN (U+0374)](https://www.fileformat.info/info/unicode/char/0374/index.htm) 	cdb4
͵ 	[GREEK LOWER NUMERAL SIGN (U+0375)](https://www.fileformat.info/info/unicode/char/0375/index.htm) 	cdb5
Ͷ 	[GREEK CAPITAL LETTER PAMPHYLIAN DIGAMMA (U+0376)](https://www.fileformat.info/info/unicode/char/0376/index.htm) 	cdb6
ͷ 	[GREEK SMALL LETTER PAMPHYLIAN DIGAMMA (U+0377)](https://www.fileformat.info/info/unicode/char/0377/index.htm) 	cdb7
ͺ 	[GREEK YPOGEGRAMMENI (U+037A)](https://www.fileformat.info/info/unicode/char/037a/index.htm) 	cdba
ͻ 	[GREEK SMALL REVERSED LUNATE SIGMA SYMBOL (U+037B)](https://www.fileformat.info/info/unicode/char/037b/index.htm) 	cdbb
ͼ 	[GREEK SMALL DOTTED LUNATE SIGMA SYMBOL (U+037C)](https://www.fileformat.info/info/unicode/char/037c/index.htm) 	cdbc
ͽ 	[GREEK SMALL REVERSED DOTTED LUNATE SIGMA SYMBOL (U+037D)](https://www.fileformat.info/info/unicode/char/037d/index.htm) 	cdbd
; 	[GREEK QUESTION MARK (U+037E)](https://www.fileformat.info/info/unicode/char/037e/index.htm) 	cdbe
Ϳ 	[GREEK CAPITAL LETTER YOT (U+037F)](https://www.fileformat.info/info/unicode/char/037f/index.htm) 	cdbf
΄ 	[GREEK TONOS (U+0384)](https://www.fileformat.info/info/unicode/char/0384/index.htm) 	ce84
΅ 	[GREEK DIALYTIKA TONOS (U+0385)](https://www.fileformat.info/info/unicode/char/0385/index.htm) 	ce85
Ά 	[GREEK CAPITAL LETTER ALPHA WITH TONOS (U+0386)](https://www.fileformat.info/info/unicode/char/0386/index.htm) 	ce86
· 	[GREEK ANO TELEIA (U+0387)](https://www.fileformat.info/info/unicode/char/0387/index.htm) 	ce87
Έ 	[GREEK CAPITAL LETTER EPSILON WITH TONOS (U+0388)](https://www.fileformat.info/info/unicode/char/0388/index.htm) 	ce88
Ή 	[GREEK CAPITAL LETTER ETA WITH TONOS (U+0389)](https://www.fileformat.info/info/unicode/char/0389/index.htm) 	ce89
Ί 	[GREEK CAPITAL LETTER IOTA WITH TONOS (U+038A)](https://www.fileformat.info/info/unicode/char/038a/index.htm) 	ce8a
Ό 	[GREEK CAPITAL LETTER OMICRON WITH TONOS (U+038C)](https://www.fileformat.info/info/unicode/char/038c/index.htm) 	ce8c
Ύ 	[GREEK CAPITAL LETTER UPSILON WITH TONOS (U+038E)](https://www.fileformat.info/info/unicode/char/038e/index.htm) 	ce8e
Ώ 	[GREEK CAPITAL LETTER OMEGA WITH TONOS (U+038F)](https://www.fileformat.info/info/unicode/char/038f/index.htm) 	ce8f
ΐ 	[GREEK SMALL LETTER IOTA WITH DIALYTIKA AND TONOS (U+0390)](https://www.fileformat.info/info/unicode/char/0390/index.htm) 	ce90
Α 	[GREEK CAPITAL LETTER ALPHA (U+0391)](https://www.fileformat.info/info/unicode/char/0391/index.htm) 	ce91
Β 	[GREEK CAPITAL LETTER BETA (U+0392)](https://www.fileformat.info/info/unicode/char/0392/index.htm) 	ce92
Γ 	[GREEK CAPITAL LETTER GAMMA (U+0393)](https://www.fileformat.info/info/unicode/char/0393/index.htm) 	ce93
Δ 	[GREEK CAPITAL LETTER DELTA (U+0394)](https://www.fileformat.info/info/unicode/char/0394/index.htm) 	ce94
Ε 	[GREEK CAPITAL LETTER EPSILON (U+0395)](https://www.fileformat.info/info/unicode/char/0395/index.htm) 	ce95
Ζ 	[GREEK CAPITAL LETTER ZETA (U+0396)](https://www.fileformat.info/info/unicode/char/0396/index.htm) 	ce96
Η 	[GREEK CAPITAL LETTER ETA (U+0397)](https://www.fileformat.info/info/unicode/char/0397/index.htm) 	ce97
Θ 	[GREEK CAPITAL LETTER THETA (U+0398)](https://www.fileformat.info/info/unicode/char/0398/index.htm) 	ce98
Ι 	[GREEK CAPITAL LETTER IOTA (U+0399)](https://www.fileformat.info/info/unicode/char/0399/index.htm) 	ce99
Κ 	[GREEK CAPITAL LETTER KAPPA (U+039A)](https://www.fileformat.info/info/unicode/char/039a/index.htm) 	ce9a
Λ 	[GREEK CAPITAL LETTER LAMDA (U+039B)](https://www.fileformat.info/info/unicode/char/039b/index.htm) 	ce9b
Μ 	[GREEK CAPITAL LETTER MU (U+039C)](https://www.fileformat.info/info/unicode/char/039c/index.htm) 	ce9c
Ν 	[GREEK CAPITAL LETTER NU (U+039D)](https://www.fileformat.info/info/unicode/char/039d/index.htm) 	ce9d
Ξ 	[GREEK CAPITAL LETTER XI (U+039E)](https://www.fileformat.info/info/unicode/char/039e/index.htm) 	ce9e
Ο 	[GREEK CAPITAL LETTER OMICRON (U+039F)](https://www.fileformat.info/info/unicode/char/039f/index.htm) 	ce9f
Π 	[GREEK CAPITAL LETTER PI (U+03A0)](https://www.fileformat.info/info/unicode/char/03a0/index.htm) 	cea0
Ρ 	[GREEK CAPITAL LETTER RHO (U+03A1)](https://www.fileformat.info/info/unicode/char/03a1/index.htm) 	cea1
Σ 	[GREEK CAPITAL LETTER SIGMA (U+03A3)](https://www.fileformat.info/info/unicode/char/03a3/index.htm) 	cea3
Τ 	[GREEK CAPITAL LETTER TAU (U+03A4)](https://www.fileformat.info/info/unicode/char/03a4/index.htm) 	cea4
Υ 	[GREEK CAPITAL LETTER UPSILON (U+03A5)](https://www.fileformat.info/info/unicode/char/03a5/index.htm) 	cea5
Φ 	[GREEK CAPITAL LETTER PHI (U+03A6)](https://www.fileformat.info/info/unicode/char/03a6/index.htm) 	cea6
Χ 	[GREEK CAPITAL LETTER CHI (U+03A7)](https://www.fileformat.info/info/unicode/char/03a7/index.htm) 	cea7
Ψ 	[GREEK CAPITAL LETTER PSI (U+03A8)](https://www.fileformat.info/info/unicode/char/03a8/index.htm) 	cea8
Ω 	[GREEK CAPITAL LETTER OMEGA (U+03A9)](https://www.fileformat.info/info/unicode/char/03a9/index.htm) 	cea9
Ϊ 	[GREEK CAPITAL LETTER IOTA WITH DIALYTIKA (U+03AA)](https://www.fileformat.info/info/unicode/char/03aa/index.htm) 	ceaa
Ϋ 	[GREEK CAPITAL LETTER UPSILON WITH DIALYTIKA (U+03AB)](https://www.fileformat.info/info/unicode/char/03ab/index.htm) 	ceab
ά 	[GREEK SMALL LETTER ALPHA WITH TONOS (U+03AC)](https://www.fileformat.info/info/unicode/char/03ac/index.htm) 	ceac
έ 	[GREEK SMALL LETTER EPSILON WITH TONOS (U+03AD)](https://www.fileformat.info/info/unicode/char/03ad/index.htm) 	cead
ή 	[GREEK SMALL LETTER ETA WITH TONOS (U+03AE)](https://www.fileformat.info/info/unicode/char/03ae/index.htm) 	ceae
ί 	[GREEK SMALL LETTER IOTA WITH TONOS (U+03AF)](https://www.fileformat.info/info/unicode/char/03af/index.htm) 	ceaf
ΰ 	[GREEK SMALL LETTER UPSILON WITH DIALYTIKA AND TONOS (U+03B0)](https://www.fileformat.info/info/unicode/char/03b0/index.htm) 	ceb0
α 	[GREEK SMALL LETTER ALPHA (U+03B1)](https://www.fileformat.info/info/unicode/char/03b1/index.htm) 	ceb1
β 	[GREEK SMALL LETTER BETA (U+03B2)](https://www.fileformat.info/info/unicode/char/03b2/index.htm) 	ceb2
γ 	[GREEK SMALL LETTER GAMMA (U+03B3)](https://www.fileformat.info/info/unicode/char/03b3/index.htm) 	ceb3
δ 	[GREEK SMALL LETTER DELTA (U+03B4)](https://www.fileformat.info/info/unicode/char/03b4/index.htm) 	ceb4
ε 	[GREEK SMALL LETTER EPSILON (U+03B5)](https://www.fileformat.info/info/unicode/char/03b5/index.htm) 	ceb5
ζ 	[GREEK SMALL LETTER ZETA (U+03B6)](https://www.fileformat.info/info/unicode/char/03b6/index.htm) 	ceb6
η 	[GREEK SMALL LETTER ETA (U+03B7)](https://www.fileformat.info/info/unicode/char/03b7/index.htm) 	ceb7
θ 	[GREEK SMALL LETTER THETA (U+03B8)](https://www.fileformat.info/info/unicode/char/03b8/index.htm) 	ceb8
ι 	[GREEK SMALL LETTER IOTA (U+03B9)](https://www.fileformat.info/info/unicode/char/03b9/index.htm) 	ceb9
κ 	[GREEK SMALL LETTER KAPPA (U+03BA)](https://www.fileformat.info/info/unicode/char/03ba/index.htm) 	ceba
λ 	[GREEK SMALL LETTER LAMDA (U+03BB)](https://www.fileformat.info/info/unicode/char/03bb/index.htm) 	cebb
μ 	[GREEK SMALL LETTER MU (U+03BC)](https://www.fileformat.info/info/unicode/char/03bc/index.htm) 	cebc
ν 	[GREEK SMALL LETTER NU (U+03BD)](https://www.fileformat.info/info/unicode/char/03bd/index.htm) 	cebd
ξ 	[GREEK SMALL LETTER XI (U+03BE)](https://www.fileformat.info/info/unicode/char/03be/index.htm) 	cebe
ο 	[GREEK SMALL LETTER OMICRON (U+03BF)](https://www.fileformat.info/info/unicode/char/03bf/index.htm) 	cebf
π 	[GREEK SMALL LETTER PI (U+03C0)](https://www.fileformat.info/info/unicode/char/03c0/index.htm) 	cf80
ρ 	[GREEK SMALL LETTER RHO (U+03C1)](https://www.fileformat.info/info/unicode/char/03c1/index.htm) 	cf81
ς 	[GREEK SMALL LETTER FINAL SIGMA (U+03C2)](https://www.fileformat.info/info/unicode/char/03c2/index.htm) 	cf82
σ 	[GREEK SMALL LETTER SIGMA (U+03C3)](https://www.fileformat.info/info/unicode/char/03c3/index.htm) 	cf83
τ 	[GREEK SMALL LETTER TAU (U+03C4)](https://www.fileformat.info/info/unicode/char/03c4/index.htm) 	cf84
υ 	[GREEK SMALL LETTER UPSILON (U+03C5)](https://www.fileformat.info/info/unicode/char/03c5/index.htm) 	cf85
φ 	[GREEK SMALL LETTER PHI (U+03C6)](https://www.fileformat.info/info/unicode/char/03c6/index.htm) 	cf86
χ 	[GREEK SMALL LETTER CHI (U+03C7)](https://www.fileformat.info/info/unicode/char/03c7/index.htm) 	cf87
ψ 	[GREEK SMALL LETTER PSI (U+03C8)](https://www.fileformat.info/info/unicode/char/03c8/index.htm) 	cf88
ω 	[GREEK SMALL LETTER OMEGA (U+03C9)](https://www.fileformat.info/info/unicode/char/03c9/index.htm) 	cf89
ϊ 	[GREEK SMALL LETTER IOTA WITH DIALYTIKA (U+03CA)](https://www.fileformat.info/info/unicode/char/03ca/index.htm) 	cf8a
ϋ 	[GREEK SMALL LETTER UPSILON WITH DIALYTIKA (U+03CB)](https://www.fileformat.info/info/unicode/char/03cb/index.htm) 	cf8b
ό 	[GREEK SMALL LETTER OMICRON WITH TONOS (U+03CC)](https://www.fileformat.info/info/unicode/char/03cc/index.htm) 	cf8c
ύ 	[GREEK SMALL LETTER UPSILON WITH TONOS (U+03CD)](https://www.fileformat.info/info/unicode/char/03cd/index.htm) 	cf8d
ώ 	[GREEK SMALL LETTER OMEGA WITH TONOS (U+03CE)](https://www.fileformat.info/info/unicode/char/03ce/index.htm) 	cf8e
Ϗ 	[GREEK CAPITAL KAI SYMBOL (U+03CF)](https://www.fileformat.info/info/unicode/char/03cf/index.htm) 	cf8f
ϐ 	[GREEK BETA SYMBOL (U+03D0)](https://www.fileformat.info/info/unicode/char/03d0/index.htm) 	cf90
ϑ 	[GREEK THETA SYMBOL (U+03D1)](https://www.fileformat.info/info/unicode/char/03d1/index.htm) 	cf91
ϒ 	[GREEK UPSILON WITH HOOK SYMBOL (U+03D2)](https://www.fileformat.info/info/unicode/char/03d2/index.htm) 	cf92
ϓ 	[GREEK UPSILON WITH ACUTE AND HOOK SYMBOL (U+03D3)](https://www.fileformat.info/info/unicode/char/03d3/index.htm) 	cf93
ϔ 	[GREEK UPSILON WITH DIAERESIS AND HOOK SYMBOL (U+03D4)](https://www.fileformat.info/info/unicode/char/03d4/index.htm) 	cf94
ϕ 	[GREEK PHI SYMBOL (U+03D5)](https://www.fileformat.info/info/unicode/char/03d5/index.htm) 	cf95
ϖ 	[GREEK PI SYMBOL (U+03D6)](https://www.fileformat.info/info/unicode/char/03d6/index.htm) 	cf96
ϗ 	[GREEK KAI SYMBOL (U+03D7)](https://www.fileformat.info/info/unicode/char/03d7/index.htm) 	cf97
Ϙ 	[GREEK LETTER ARCHAIC KOPPA (U+03D8)](https://www.fileformat.info/info/unicode/char/03d8/index.htm) 	cf98
ϙ 	[GREEK SMALL LETTER ARCHAIC KOPPA (U+03D9)](https://www.fileformat.info/info/unicode/char/03d9/index.htm) 	cf99
Ϛ 	[GREEK LETTER STIGMA (U+03DA)](https://www.fileformat.info/info/unicode/char/03da/index.htm) 	cf9a
ϛ 	[GREEK SMALL LETTER STIGMA (U+03DB)](https://www.fileformat.info/info/unicode/char/03db/index.htm) 	cf9b
Ϝ 	[GREEK LETTER DIGAMMA (U+03DC)](https://www.fileformat.info/info/unicode/char/03dc/index.htm) 	cf9c
ϝ 	[GREEK SMALL LETTER DIGAMMA (U+03DD)](https://www.fileformat.info/info/unicode/char/03dd/index.htm) 	cf9d
Ϟ 	[GREEK LETTER KOPPA (U+03DE)](https://www.fileformat.info/info/unicode/char/03de/index.htm) 	cf9e
ϟ 	[GREEK SMALL LETTER KOPPA (U+03DF)](https://www.fileformat.info/info/unicode/char/03df/index.htm) 	cf9f
Ϡ 	[GREEK LETTER SAMPI (U+03E0)](https://www.fileformat.info/info/unicode/char/03e0/index.htm) 	cfa0
ϡ 	[GREEK SMALL LETTER SAMPI (U+03E1)](https://www.fileformat.info/info/unicode/char/03e1/index.htm) 	cfa1
Ϣ 	[COPTIC CAPITAL LETTER SHEI (U+03E2)](https://www.fileformat.info/info/unicode/char/03e2/index.htm) 	cfa2
ϣ 	[COPTIC SMALL LETTER SHEI (U+03E3)](https://www.fileformat.info/info/unicode/char/03e3/index.htm) 	cfa3
Ϥ 	[COPTIC CAPITAL LETTER FEI (U+03E4)](https://www.fileformat.info/info/unicode/char/03e4/index.htm) 	cfa4
ϥ 	[COPTIC SMALL LETTER FEI (U+03E5)](https://www.fileformat.info/info/unicode/char/03e5/index.htm) 	cfa5
Ϧ 	[COPTIC CAPITAL LETTER KHEI (U+03E6)](https://www.fileformat.info/info/unicode/char/03e6/index.htm) 	cfa6
ϧ 	[COPTIC SMALL LETTER KHEI (U+03E7)](https://www.fileformat.info/info/unicode/char/03e7/index.htm) 	cfa7
Ϩ 	[COPTIC CAPITAL LETTER HORI (U+03E8)](https://www.fileformat.info/info/unicode/char/03e8/index.htm) 	cfa8
ϩ 	[COPTIC SMALL LETTER HORI (U+03E9)](https://www.fileformat.info/info/unicode/char/03e9/index.htm) 	cfa9
Ϫ 	[COPTIC CAPITAL LETTER GANGIA (U+03EA)](https://www.fileformat.info/info/unicode/char/03ea/index.htm) 	cfaa
ϫ 	[COPTIC SMALL LETTER GANGIA (U+03EB)](https://www.fileformat.info/info/unicode/char/03eb/index.htm) 	cfab
Ϭ 	[COPTIC CAPITAL LETTER SHIMA (U+03EC)](https://www.fileformat.info/info/unicode/char/03ec/index.htm) 	cfac
ϭ 	[COPTIC SMALL LETTER SHIMA (U+03ED)](https://www.fileformat.info/info/unicode/char/03ed/index.htm) 	cfad
Ϯ 	[COPTIC CAPITAL LETTER DEI (U+03EE)](https://www.fileformat.info/info/unicode/char/03ee/index.htm) 	cfae
ϯ 	[COPTIC SMALL LETTER DEI (U+03EF)](https://www.fileformat.info/info/unicode/char/03ef/index.htm) 	cfaf
ϰ 	[GREEK KAPPA SYMBOL (U+03F0)](https://www.fileformat.info/info/unicode/char/03f0/index.htm) 	cfb0
ϱ 	[GREEK RHO SYMBOL (U+03F1)](https://www.fileformat.info/info/unicode/char/03f1/index.htm) 	cfb1
ϲ 	[GREEK LUNATE SIGMA SYMBOL (U+03F2)](https://www.fileformat.info/info/unicode/char/03f2/index.htm) 	cfb2
ϳ 	[GREEK LETTER YOT (U+03F3)](https://www.fileformat.info/info/unicode/char/03f3/index.htm) 	cfb3
ϴ 	[GREEK CAPITAL THETA SYMBOL (U+03F4)](https://www.fileformat.info/info/unicode/char/03f4/index.htm) 	cfb4
ϵ 	[GREEK LUNATE EPSILON SYMBOL (U+03F5)](https://www.fileformat.info/info/unicode/char/03f5/index.htm) 	cfb5
϶ 	[GREEK REVERSED LUNATE EPSILON SYMBOL (U+03F6)](https://www.fileformat.info/info/unicode/char/03f6/index.htm) 	cfb6
Ϸ 	[GREEK CAPITAL LETTER SHO (U+03F7)](https://www.fileformat.info/info/unicode/char/03f7/index.htm) 	cfb7
ϸ 	[GREEK SMALL LETTER SHO (U+03F8)](https://www.fileformat.info/info/unicode/char/03f8/index.htm) 	cfb8
Ϲ 	[GREEK CAPITAL LUNATE SIGMA SYMBOL (U+03F9)](https://www.fileformat.info/info/unicode/char/03f9/index.htm) 	cfb9
Ϻ 	[GREEK CAPITAL LETTER SAN (U+03FA)](https://www.fileformat.info/info/unicode/char/03fa/index.htm) 	cfba
ϻ 	[GREEK SMALL LETTER SAN (U+03FB)](https://www.fileformat.info/info/unicode/char/03fb/index.htm) 	cfbb
ϼ 	[GREEK RHO WITH STROKE SYMBOL (U+03FC)](https://www.fileformat.info/info/unicode/char/03fc/index.htm) 	cfbc
Ͻ 	[GREEK CAPITAL REVERSED LUNATE SIGMA SYMBOL (U+03FD)](https://www.fileformat.info/info/unicode/char/03fd/index.htm) 	cfbd
Ͼ 	[GREEK CAPITAL DOTTED LUNATE SIGMA SYMBOL (U+03FE)](https://www.fileformat.info/info/unicode/char/03fe/index.htm) 	cfbe
Ͽ 	[GREEK CAPITAL REVERSED DOTTED LUNATE SIGMA SYMBOL (U+03FF)](https://www.fileformat.info/info/unicode/char/03ff/index.htm) 	cfbf
Ѐ 	[CYRILLIC CAPITAL LETTER IE WITH GRAVE (U+0400)](https://www.fileformat.info/info/unicode/char/0400/index.htm) 	d080
Ё 	[CYRILLIC CAPITAL LETTER IO (U+0401)](https://www.fileformat.info/info/unicode/char/0401/index.htm) 	d081
Ђ 	[CYRILLIC CAPITAL LETTER DJE (U+0402)](https://www.fileformat.info/info/unicode/char/0402/index.htm) 	d082
Ѓ 	[CYRILLIC CAPITAL LETTER GJE (U+0403)](https://www.fileformat.info/info/unicode/char/0403/index.htm) 	d083
Є 	[CYRILLIC CAPITAL LETTER UKRAINIAN IE (U+0404)](https://www.fileformat.info/info/unicode/char/0404/index.htm) 	d084
Ѕ 	[CYRILLIC CAPITAL LETTER DZE (U+0405)](https://www.fileformat.info/info/unicode/char/0405/index.htm) 	d085
І 	[CYRILLIC CAPITAL LETTER BYELORUSSIAN-UKRAINIAN I (U+0406)](https://www.fileformat.info/info/unicode/char/0406/index.htm) 	d086
Ї 	[CYRILLIC CAPITAL LETTER YI (U+0407)](https://www.fileformat.info/info/unicode/char/0407/index.htm) 	d087
Ј 	[CYRILLIC CAPITAL LETTER JE (U+0408)](https://www.fileformat.info/info/unicode/char/0408/index.htm) 	d088
[More...](https://www.fileformat.info/info/charset/UTF-8/list.htm?start=1024)